### PR TITLE
primary update of the Task interface with context

### DIFF
--- a/pkg/utils/timeout.go
+++ b/pkg/utils/timeout.go
@@ -5,7 +5,7 @@ import (
 	"time"
 )
 
-func RunWithTimeout(f func() error, timeout time.Duration) error {
+func RunWithTimeout(f func(ctx context.Context) error, timeout time.Duration) error {
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
@@ -14,7 +14,7 @@ func RunWithTimeout(f func() error, timeout time.Duration) error {
 	go func() {
 		defer close(done)
 
-		done <- f()
+		done <- f(ctx)
 	}()
 
 	select {

--- a/pkg/utils/timeout_test.go
+++ b/pkg/utils/timeout_test.go
@@ -1,6 +1,7 @@
 package utils_test
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -8,7 +9,7 @@ import (
 )
 
 func TestRunWithTimeout(t *testing.T) {
-	task := func() error {
+	task := func(_ context.Context) error {
 		time.Sleep(2 * time.Second)
 		return nil
 	}

--- a/scheduler_test.go
+++ b/scheduler_test.go
@@ -1,6 +1,7 @@
 package gojob_test
 
 import (
+	"context"
 	"fmt"
 	"reflect"
 	"sort"
@@ -46,7 +47,7 @@ func newTask(i int, writer *safeWriter) *schedulerTestTask {
 	}
 }
 
-func (t *schedulerTestTask) Do() error {
+func (t *schedulerTestTask) Do(_ context.Context) error {
 	t.writer.WriteString(fmt.Sprintf("%d\n", t.I))
 	return nil
 }

--- a/task.go
+++ b/task.go
@@ -1,6 +1,8 @@
 package gojob
 
 import (
+	"context"
+
 	"github.com/google/uuid"
 )
 
@@ -9,7 +11,7 @@ type Task interface {
 	// Do starts the task, returns error if failed
 	// If an error is returned, the task will be retried until MaxRetries
 	// You can set MaxRetries by calling SetMaxRetries on the scheduler
-	Do() error
+	Do(context.Context) error
 }
 
 type basicTask struct {


### PR DESCRIPTION
Closes #6 

This update adds a breaking change, by adding context to `Do` function of the `Task` interface.
It does not cover all possible usages and improvements, which can be achieved with context, but it's the start

UPD: build is failing on examples, which do not have context. I'd prefer to update them in different PR, if you don't mind.